### PR TITLE
use new api version for ingress

### DIFF
--- a/stable/grc/templates/grcui-ingress.yaml
+++ b/stable/grc/templates/grcui-ingress.yaml
@@ -20,7 +20,10 @@ spec:
   rules:
   - http:
       paths:
-      - path: /multicloud/policies
-        backend:
-          serviceName: {{ .Release.Name }}-grcui
-          servicePort: 3000
+      - backend:
+          service:
+            name: {{ .Release.Name }}-grcui
+            port:
+              number: 3000
+        path: /multicloud/policies
+        pathType: ImplementationSpecific

--- a/stable/grc/templates/grcui-ingress.yaml
+++ b/stable/grc/templates/grcui-ingress.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Red Hat, Inc.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
Needed due to:
```
W0312 22:36:29.019020       1 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```
Issue https://github.com/open-cluster-management/backlog/issues/10344