### PR TITLE
need new role for allowing operator to create policies

### DIFF
--- a/stable/grc/templates/grc-clusterrole.yaml
+++ b/stable/grc/templates/grc-clusterrole.yaml
@@ -87,3 +87,9 @@ rules:
   - 'tokenreviews'
   verbs:
   - create
+- apiGroups:
+  - '*'
+  resources:
+  - '*/finalizers'
+  verbs:
+  - update


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
Customer requested in https://github.com/open-cluster-management/backlog/issues/13607 to be able to create policies from their operator.  To allow any operator to create a policy we needed to add this permission.

Let me know if there are any concerns with this additional permission.