### PR TITLE
Expose propagator metrics

### DIFF
--- a/stable/grc/templates/grc-clusterrole.yaml
+++ b/stable/grc/templates/grc-clusterrole.yaml
@@ -88,6 +88,12 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - '*'
   resources:
   - '*/finalizers'

--- a/stable/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/stable/grc/templates/grc-policy-propagator-deployment.yaml
@@ -80,6 +80,24 @@ spec:
           key: node-role.kubernetes.io/infra 
           operator: Exists
       containers:
+      - name: kube-rbac-proxy
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7
+        imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+        args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8383/
+        - --logtostderr=true
+        - --v=10
+        - "--tls-cert-file=/var/run/policy-metrics-cert/tls.crt"
+        - "--tls-private-key-file=/var/run/policy-metrics-cert/tls.key"
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        volumeMounts:
+        - mountPath: "/var/run/policy-metrics-cert"
+          name: metrics-cert
+          readOnly: true
       - name: governance-policy-propagator
         image: {{ .Values.global.imageOverrides.governance_policy_propagator}}
         imagePullPolicy: "{{ .Values.global.pullPolicy }}"
@@ -121,6 +139,9 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
+      - name: metrics-cert
+        secret:
+          secretName: {{ .Release.Name }}-grc-metrics-cert
       {{- if .Values.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.pullSecret }}

--- a/stable/grc/templates/grc-policy-propagator-metrics-service.yaml
+++ b/stable/grc/templates/grc-policy-propagator-metrics-service.yaml
@@ -1,0 +1,30 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-policy-propagator-metrics
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ .Release.Name }}-grc-metrics-cert
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: {{ template "grc.name" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/stable/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
+++ b/stable/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
@@ -1,0 +1,36 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ocm-{{ .Release.Name }}-policy-propagator-metrics
+  namespace: openshift-monitoring
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    interval: 60s
+    scrapeTimeout: 10s
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: ocm-grc-policy-propagator
+  namespaceSelector:
+    matchNames:
+    - open-cluster-management
+  selector:
+    matchLabels:
+      app: {{ template "grc.name" . }}
+      component: "ocm-policy-propagator"
+      release: {{ .Release.Name }}


### PR DESCRIPTION
This adds an rbac proxy container to the propagator, which will protect
the (newly exposed) metrics endpoint. The new service will also help
generate a certificate for this endpoint to use, to be connected to by
the new ServiceMonitor, which will bring the metrics into the OCP
prometheus.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/14583
 - https://github.com/open-cluster-management/backlog/issues/14727

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

Some details for the service/servicemonitor configuration were taken from the insights chart: https://github.com/open-cluster-management/insights-chart/tree/main/stable/insights-chart/templates