### PR TITLE
Add read access for template lookup resources

### DIFF
--- a/stable/grc/templates/grc-clusterrole.yaml
+++ b/stable/grc/templates/grc-clusterrole.yaml
@@ -101,6 +101,13 @@ rules:
   - '*/finalizers'
   verbs:
   - update
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
 
 ---
 


### PR DESCRIPTION
Signed-off-by: ckandag <ckandaga@redhat.com>

Since the templates can references any namespaced resource.  We need to allow the propagator controller to read any resource.  The limitation to read within the namespace is enforced in the code.  fyi @gparvin 

