### PR TITLE
Use the ocm fork of the kube rbac proxy

### DIFF
--- a/stable/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/stable/grc/templates/grc-policy-propagator-deployment.yaml
@@ -81,7 +81,7 @@ spec:
           operator: Exists
       containers:
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7
+        image: {{ .Values.global.imageOverrides.kube_rbac_proxy}}
         imagePullPolicy: "{{ .Values.global.pullPolicy }}"
         args:
         - --secure-listen-address=0.0.0.0:8443

--- a/stable/grc/values.yaml
+++ b/stable/grc/values.yaml
@@ -7,6 +7,7 @@ global:
     governance_policy_propagator: ""
     grc_ui: ""
     grc_ui_api: ""
+    kube_rbac_proxy: ""
   pullPolicy: Always
 
 arch:


### PR DESCRIPTION
In disconnected environments, the previous image might not be present
because it was not specified in the related images of the operator. But
we have a fork of the kube-rbac-proxy that we are maintaining, so this
can be supplied at deploy-time easily.

That image is already mentioned in the relatedImages section of the
operator's packagemanifest, so it seems nothing needs to be added there.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/15904

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>