### PR TITLE
Add lease permissions for leader election

### DIFF
--- a/stable/grc/templates/grc-role.yaml
+++ b/stable/grc/templates/grc-role.yaml
@@ -89,3 +89,15 @@ rules:
   - deployments
   verbs:
   - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
After updgrading the controller-runtime libraries on the propagator,
these permissions are required for a leader election.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/15548

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>