### PR TITLE
Reduce rbac container log level

### DIFF
--- a/stable/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/stable/grc/templates/grc-policy-propagator-deployment.yaml
@@ -87,7 +87,7 @@ spec:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8383/
         - --logtostderr=true
-        - --v=10
+        - --v=6
         - "--tls-cert-file=/var/run/policy-metrics-cert/tls.crt"
         - "--tls-private-key-file=/var/run/policy-metrics-cert/tls.key"
         ports:


### PR DESCRIPTION
The container logs were very verbose - potentially leaking information
to users that shouldn't have it.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/16712

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>