### PR TITLE
Add aggregation rules for propagator metric

### DIFF
--- a/stable/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
+++ b/stable/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
@@ -1,0 +1,29 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ocm-{{ .Release.Name }}-policy-propagator-metrics
+  namespace: openshift-monitoring
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+spec:
+  groups:
+  - name: policy_governance_info.rules
+    rules:
+    - record: cluster:policy_governance_info:propagated_count
+      expr: count by (cluster_namespace) (policy_governance_info{type="propagated"})
+    - record: cluster:policy_governance_info:propagated_noncompliant_count
+      expr: count by (cluster_namespace) (policy_governance_info{type="propagated"}==1)
+    - record: policy:policy_governance_info:propagated_count
+      expr: count by (policy) (policy_governance_info{type="propagated"})
+    - record: policy:policy_governance_info:propagated_noncompliant_count
+      expr: count by (policy) (policy_governance_info{type="propagated"}==1)


### PR DESCRIPTION
Since this metric can have a very large number of time series (one for
every distributed policy), we want to provide a way to store some
aggregations of it in ACM observabillity. These rules make what we
expect to be common requests: total and noncompliant counts by both
cluster and policy.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/16198
 - https://github.com/open-cluster-management/multicluster-observability-operator/pull/789

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>